### PR TITLE
Terraform 1

### DIFF
--- a/packer/ubuntu16.json
+++ b/packer/ubuntu16.json
@@ -5,10 +5,10 @@
 		"project_id": null,
 		"source_image": null,
 		"machine_type": "f1-micro",
-		"disk_size": 10,
+		"disk_size": "10",
 		"disk_type": "pd-standard",
 		"network": "default",
-		"tags":""
+		"tags":"reddit-app"
 	},
 
 	"builders": [
@@ -21,7 +21,7 @@
 		"ssh_username": "appuser",
 		"machine_type": "{{user `machine_type`}}",
 		"disk_size": "{{user `disk_size`}}",
-		"disk_type": "{{user `disk_size`}}",
+		"disk_type": "{{user `disk_type`}}",
 		"network": "{{user `network`}}",
 		"tags": "{{user `tags`}}"
 	}

--- a/terraform/files/deploy.sh
+++ b/terraform/files/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+source ~/.profile
+git clone https://github.com/Artemmkin/reddit.git
+cd reddit
+bundle install
+
+sudo mv /tmp/puma.service /etc/systemd/system/puma.service
+sudo systemctl start puma
+#sudo systemctl enable puma

--- a/terraform/files/puma.service
+++ b/terraform/files/puma.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Puma HTTP Server
+After=network.target
+
+[Service]
+Type=simple
+User=appuser
+WorkingDirectory=/home/appuser/reddit
+ExecStart=/bin/bash -lc 'puma'
+Restart=always
+
+[Install]
+WantedBy=multi-user.targetS

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,6 +27,8 @@ resource "google_compute_instance" "app" {
   connection {
     type = "ssh"
     user = "appuser"
+    agent = false
+    private_key = "${file("~/.ssh/appuser")}"
   }
 
   provisioner "file" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,55 @@
+provider "google" {
+  project = "infra-180517"
+  region = "europe-west1"
+}
+
+resource "google_compute_instance" "app" {
+  name = "reddit-app"
+  machine_type = "g1-small"
+  zone = "europe-west1-b"
+
+  boot_disk {
+    initialize_params {
+      image = "reddit-base-1505931307"
+    }
+  }
+
+  metadata {
+  sshKeys = "appuser:${file("~/.ssh/appuser.pub")}"
+  }
+
+  tags = ["reddit-app"]
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  connection {
+    type = "ssh"
+    user = "appuser"
+  }
+
+  provisioner "file" {
+    source = "files/puma.service"
+    destination = "/tmp/puma.service"
+  }
+
+  provisioner "remote-exec" {
+    script = "files/deploy.sh"
+    }
+  }
+
+resource "google_compute_firewall" "firewall_puma" {
+  name = "allow-puma-default"
+  # Название сети, в которой действует правило
+  network = "default"
+  # Какой доступ разрешить
+  allow {
+  protocol = "tcp"
+  ports = ["9292"]
+  }
+  # Каким адресам разрешаем доступ
+  source_ranges = ["0.0.0.0/0"]
+  # Правило применимо для инстансов с тегом ...
+  target_tags = ["reddit-app"]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "app_external_ip" {
+  value = "${google_compute_instance.app.network_interface.0.access_config.0.assigned_nat_ip}"
+}


### PR DESCRIPTION
в `terraform/files/deploy.sh` пришлось закоментировать комманду 
`sudo systemctl enable puma` иначе ошибка при ее выполнении 

> Failed to execute operation: Invalid argument

и в unit файле удалил строчку 
`EnvironmentFile=/home/appuser/db_config` иначе тоже ошибка нет такой папки

сейчас puma server запускается, но не в автозагрузке.